### PR TITLE
RSA Support & Added Copy & Paste Gizmos to the Item Puller

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Transport.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Transport.xml
@@ -205,9 +205,6 @@
       <li>
         <compClass>ProjectRimFactory.Common.CompPRFHelp</compClass>
       </li>
-      <li>
-        <compClass>ProjectRimFactory.AutoMachineTool.Comp_CopyAndPaste</compClass>
-      </li>
     </comps>
     <modExtensions>
       <li Class="ProjectRimFactory.AutoMachineTool.ModExtension_WorkSpeed">
@@ -232,7 +229,7 @@
       </li>
     </modExtensions>
     <inspectorTabs>
-      <li>ProjectRimFactory.AutoMachineTool.ITab_PullerFilter</li>
+      <li>ITab_Storage</li>
       <li>ProjectRimFactory.Common.ITab_PowerSupply</li>
       <li>ProjectRimFactory.AutoMachineTool.ITab_ProductLimitation</li>
     </inspectorTabs>

--- a/Source/ProjectRimFactory/AutoMachineTool/Building_HarvestPuller.cs
+++ b/Source/ProjectRimFactory/AutoMachineTool/Building_HarvestPuller.cs
@@ -24,14 +24,14 @@ namespace ProjectRimFactory.AutoMachineTool
             if (this.takeForbiddenItems)
                 return z.AllContainedThings
                     .Where(t => t.def.category == ThingCategory.Item)
-                    .Where(t => this.filter.Allows(t))
+                    .Where(t => this.settings.AllowedToAccept(t))
                     .Where(t => !this.IsLimit(t))
                     .FirstOption();
             else
                 return z.AllContainedThings
                     .Where(t => t.def.category == ThingCategory.Item)
                     .Where(t => !t.IsForbidden(Faction.OfPlayer))
-                    .Where(t => this.filter.Allows(t))
+                    .Where(t => this.settings.AllowedToAccept(t))
                     .Where(t => !this.IsLimit(t))
                     .FirstOption();
         }

--- a/Source/ProjectRimFactory/AutoMachineTool/Building_ItemPuller.cs
+++ b/Source/ProjectRimFactory/AutoMachineTool/Building_ItemPuller.cs
@@ -14,11 +14,8 @@ using ProjectRimFactory.Common;
 
 namespace ProjectRimFactory.AutoMachineTool
 {
-    public class Building_ItemPuller : Building_BaseLimitation<Thing>, IStorageSetting
+    public class Building_ItemPuller : Building_BaseLimitation<Thing>, IStorageSetting, IStoreSettingsParent
     {
-        public ThingFilter Filter { get => this.filter; }
-
-        protected ThingFilter filter = new ThingFilter();
         protected bool active = false;
         protected bool takeForbiddenItems=true;
         public override Graphic Graphic => this.def.GetModExtension<ModExtension_Graphic>()?.GetByName(GetGraphicName()) ?? base.Graphic;
@@ -36,6 +33,26 @@ namespace ProjectRimFactory.AutoMachineTool
             }
             return name;
         }
+
+        public bool StorageTabVisible => true;
+
+        public StorageSettings settings;
+
+        public StorageSettings GetStoreSettings()
+        {
+            if (settings == null)
+            {
+                settings = new StorageSettings();
+                //To "Prevent" a null Refrence as GetParentStoreSettings() seems to be null on first Placing the Building
+                if (GetParentStoreSettings() != null) { 
+                    settings.CopyFrom(GetParentStoreSettings());
+                }
+            }
+            return settings;
+        }
+
+        public StorageSettings GetParentStoreSettings() => def.building.fixedStorageSettings;
+
 
         [Unsaved]
         protected StorageSettings storageSettings;
@@ -60,25 +77,21 @@ namespace ProjectRimFactory.AutoMachineTool
 
             base.ExposeData();
 
-            Scribe_Deep.Look<ThingFilter>(ref this.filter, "filter");
             Scribe_Values.Look<bool>(ref this.active, "active", false);
             Scribe_Values.Look<bool>(ref this.right, "right", false);
+            Scribe_Deep.Look(ref settings, "settings", this);
             Scribe_Values.Look<bool>(ref this.takeForbiddenItems, "takeForbidden", true);
-
-            if (this.filter == null) this.filter = new ThingFilter();
-
-            this.storageSettings = new StorageSettings { filter = this.filter };
         }
 
         public override void SpawnSetup(Map map, bool respawningAfterLoad)
         {
             base.SpawnSetup(map, respawningAfterLoad);
 
+            settings = GetStoreSettings();
+
             if (!respawningAfterLoad)
             {
-                this.filter = new ThingFilter();
-                this.filter.SetAllowAll(null);
-                this.storageSettings = new StorageSettings { filter = this.filter };
+                
             }
             this.forcePlace = this.ForcePlace;
         }
@@ -106,7 +119,7 @@ namespace ProjectRimFactory.AutoMachineTool
                 return (this.Position + this.Rotation.Opposite.FacingCell).SlotGroupCells(this.Map)
                     .SelectMany(c => c.GetThingList(this.Map))
                     .Where(t => t.def.category == ThingCategory.Item)
-                    .Where(t => this.filter.Allows(t))
+                    .Where(t => this.settings.AllowedToAccept(t))
                     .Where(t => !this.IsLimit(t))
                     .FirstOption();
             else
@@ -114,7 +127,7 @@ namespace ProjectRimFactory.AutoMachineTool
                     .SelectMany(c => c.GetThingList(this.Map))
                     .Where(t => t.def.category == ThingCategory.Item)
                     .Where(t => !t.IsForbidden(Faction.OfPlayer))
-                    .Where(t => this.filter.Allows(t))
+                    .Where(t => this.settings.AllowedToAccept(t))
                     .Where(t => !this.IsLimit(t))
                     .FirstOption();
         }
@@ -125,7 +138,7 @@ namespace ProjectRimFactory.AutoMachineTool
                 return (this.Position + this.Rotation.Opposite.FacingCell).GetThingList(this.Map)
                     .OfType<Building_BeltConveyor>() // get any conveyors, also casts to conveyors
                     .Where(b => !b.IsUnderground && b.Carrying() != null)
-                    .Where(b => this.filter.Allows(b.Carrying()))
+                    .Where(b => this.settings.AllowedToAccept(b.Carrying()))
                     .Where(b => !this.IsLimit(b.Carrying()))
                     .FirstOption();
             else
@@ -133,7 +146,7 @@ namespace ProjectRimFactory.AutoMachineTool
                     .OfType<Building_BeltConveyor>() // get any conveyors, also casts to conveyors
                     .Where(b => !b.IsUnderground && b.Carrying() != null)
                     .Where(b => !b.Carrying().IsForbidden(Faction.OfPlayer))
-                    .Where(b => this.filter.Allows(b.Carrying()))
+                    .Where(b => this.settings.AllowedToAccept(b.Carrying()))
                     .Where(b => !this.IsLimit(b.Carrying()))
                     .FirstOption();
         }
@@ -161,7 +174,8 @@ namespace ProjectRimFactory.AutoMachineTool
             {
                 yield return g;
             }
-
+            foreach (Gizmo g2 in StorageSettingsClipboard.CopyPasteGizmosFor(settings))
+                yield return g2;
             yield return new Command_Toggle()
             {
                 isActive = () => this.active,

--- a/Source/ProjectRimFactory/AutoMachineTool/ITab_PullerFilter.cs
+++ b/Source/ProjectRimFactory/AutoMachineTool/ITab_PullerFilter.cs
@@ -11,62 +11,63 @@ using static ProjectRimFactory.AutoMachineTool.Ops;
 
 namespace ProjectRimFactory.AutoMachineTool
 {
-    class ITab_PullerFilter : ITab
-    {
-        private static readonly Vector2 WinSize = new Vector2(300f, 500f);
+    //class ITab_PullerFilter : ITab_Storage
+    //{
 
-        public ITab_PullerFilter()
-        {
-            this.size = WinSize;
-            this.labelKey = "PRF.AutoMachineTool.Puller.OutputItemFilter.TabName";
+    //    private static readonly Vector2 WinSize = new Vector2(300f, 500f);
 
-            this.description = "PRF.AutoMachineTool.Puller.OutputItemFilter.Description".Translate();
-        }
+    //    public ITab_PullerFilter()
+    //    {
+    //        this.size = WinSize;
+    //        this.labelKey = "PRF.AutoMachineTool.Puller.OutputItemFilter.TabName";
 
-        private string description;
+    //        this.description = "PRF.AutoMachineTool.Puller.OutputItemFilter.Description".Translate();
+    //    }
 
-        private Building_ItemPuller Puller
-        {
-            get => (Building_ItemPuller)this.SelThing;
-        }
+    //    private string description;
 
-        public override void OnOpen()
-        {
-            base.OnOpen();
+    //    private Building_ItemPuller Puller
+    //    {
+    //        get => (Building_ItemPuller)this.SelThing;
+    //    }
 
-            this.groups = this.Puller.Map.haulDestinationManager.AllGroups.ToList();
-        }
+    //    public override void OnOpen()
+    //    {
+    //        base.OnOpen();
 
-        private List<SlotGroup> groups;
+    //        this.groups = this.Puller.Map.haulDestinationManager.AllGroups.ToList();
+    //    }
 
-        public override bool IsVisible => Puller.Filter != null;
-        
-        private Vector2 scrollPosition;
+    //    private List<SlotGroup> groups;
 
-        protected override void FillTab()
-        {
-            Listing_Standard list = new Listing_Standard();
-            Rect inRect = new Rect(0f, 0f, WinSize.x, WinSize.y).ContractedBy(10f);
+    //    public override bool IsVisible => Puller.Filter != null;
 
-            list.Begin(inRect);
-            list.Gap();
+    //    private Vector2 scrollPosition;
 
-            var rect = list.GetRect(40f);
-            Widgets.Label(rect, this.description);
-            list.Gap();
+    //    protected override void FillTab()
+    //    {
+    //        Listing_Standard list = new Listing_Standard();
+    //        Rect inRect = new Rect(0f, 0f, WinSize.x, WinSize.y).ContractedBy(10f);
 
-            rect = list.GetRect(30f);
-            if (Widgets.ButtonText(rect, "PRF.AutoMachineTool.Puller.FilterCopyFrom".Translate()))
-            {
-                Find.WindowStack.Add(new FloatMenu(groups.Select(g => new FloatMenuOption(g.parent.SlotYielderLabel(), () => this.Puller.Filter.CopyAllowancesFrom(g.Settings.filter))).ToList()));
-            }
-            list.Gap();
+    //        list.Begin(inRect);
+    //        list.Gap();
 
-            list.End();
-            var height = list.CurHeight;
+    //        var rect = list.GetRect(40f);
+    //        Widgets.Label(rect, this.description);
+    //        list.Gap();
 
-            ThingFilterUI.DoThingFilterConfigWindow(inRect.BottomPartPixels(inRect.height - height), ref this.scrollPosition, this.Puller.Filter);
+    //        rect = list.GetRect(30f);
+    //        if (Widgets.ButtonText(rect, "PRF.AutoMachineTool.Puller.FilterCopyFrom".Translate()))
+    //        {
+    //            Find.WindowStack.Add(new FloatMenu(groups.Select(g => new FloatMenuOption(g.parent.SlotYielderLabel(), () => this.Puller.Filter.CopyAllowancesFrom(g.Settings.filter))).ToList()));
+    //        }
+    //        list.Gap();
 
-        }
-    }
+    //        list.End();
+    //        var height = list.CurHeight;
+
+    //        ThingFilterUI.DoThingFilterConfigWindow(inRect.BottomPartPixels(inRect.height - height), ref this.scrollPosition, this.Puller.Filter);
+
+    //    }
+    //}
 }


### PR DESCRIPTION
resolves #55 search bar on the puller storage UI

This adds the the RSA Support by using the Default Storage Tab
Also adds the Copy & Paste Gizmos to replace the now missing "Select copy from" Button

Notes:
`Source/ProjectRimFactory/AutoMachineTool/ITab_PullerFilter.cs` --> Just commented out for now we can probably just delete it entirely. 

`Source/ProjectRimFactory/AutoMachineTool/Building_ItemPuller.cs` Line 47 - 48: Thats probably not how I'm supposed to prevent that NullReference Error. 