### PR TITLE
Fixed ProjectRimFactory.AutoMachineTool.Graphic_Linked2.DrawWorker

### DIFF
--- a/Source/ProjectRimFactory/AutoMachineTool/Graphic_Linked2.cs
+++ b/Source/ProjectRimFactory/AutoMachineTool/Graphic_Linked2.cs
@@ -100,6 +100,9 @@ namespace ProjectRimFactory.AutoMachineTool
                 GraphicDatabase.Get<Graphic_Single>(thingDef.uiIconPath, ShaderTypeDefOf.EdgeDetect.Shader, thingDef.graphicData.drawSize, this.color, this.colorTwo)
                     .DrawWorker(loc, rot, thingDef, thing, extraRotation);
             }
+            else {
+                base.DrawWorker(loc,rot,thingDef,thing,extraRotation);
+            }
 
         }
     }

--- a/Source/ProjectRimFactory/AutoMachineTool/Graphic_Linked2.cs
+++ b/Source/ProjectRimFactory/AutoMachineTool/Graphic_Linked2.cs
@@ -95,8 +95,12 @@ namespace ProjectRimFactory.AutoMachineTool
 
         public override void DrawWorker(Vector3 loc, Rot4 rot, ThingDef thingDef, Thing thing, float extraRotation)
         {
-            GraphicDatabase.Get<Graphic_Single>(thingDef.uiIconPath, ShaderTypeDefOf.EdgeDetect.Shader, thingDef.graphicData.drawSize, this.color, this.colorTwo)
-                .DrawWorker(loc, rot, thingDef, thing, extraRotation);
+            if (!(thing is MinifiedThing))
+            {
+                GraphicDatabase.Get<Graphic_Single>(thingDef.uiIconPath, ShaderTypeDefOf.EdgeDetect.Shader, thingDef.graphicData.drawSize, this.color, this.colorTwo)
+                    .DrawWorker(loc, rot, thingDef, thing, extraRotation);
+            }
+
         }
     }
 


### PR DESCRIPTION
This fixes the Belt uninstall / Reinstall Issues.

Known side effect:
- There is no image for the Minified Thing

Maybe we should resolve that one before merging it.