### PR TITLE
Added the needed code to consume fuel

### DIFF
--- a/Source/ProjectRimFactory/SAL3/Things/Assemblers/Building_ProgrammableAssembler.cs
+++ b/Source/ProjectRimFactory/SAL3/Things/Assemblers/Building_ProgrammableAssembler.cs
@@ -311,6 +311,11 @@ namespace ProjectRimFactory.SAL3.Things.Assemblers
                     this.GetComp<CompGlowerPulse>().Glows = false;
                 }
             }
+            //Fuel
+            if (compRefuelable != null && Active && currentBillReport != null) {
+                compRefuelable.Notify_UsedThisTick();
+            }
+
         }
         // TryGetNextBill returns a new BillReport to start if one is available
         protected BillReport TryGetNextBill()


### PR DESCRIPTION
resolves #165 

Adds a call to consume fuel per tick if all of the following conditions are met:
- Building uses fuel
- Building is active / has fuel
- Building is working on a bill


TODO:
- [ ] Add support to the full XML config capability's of `compRefuelable` instead of just the only current use case. (TBD if this is blocking the initial fix @lilwhitemouse )
