### PR TITLE
Issue123

### DIFF
--- a/Source/ProjectRimFactory/Common/HarmonyPatches/Patch_GenRecipe_MakeRecipeProducts.cs
+++ b/Source/ProjectRimFactory/Common/HarmonyPatches/Patch_GenRecipe_MakeRecipeProducts.cs
@@ -139,17 +139,17 @@ namespace ProjectRimFactory.Common.HarmonyPatches
     {
         static bool Prefix(ref QualityCategory __result, Pawn pawn, SkillDef relevantSkill )
         {
-            if ( PatchStorageUtil.Get<ILearningAssemblerProgress>(pawn.Map, pawn.Position) != null) {
-                __result = PatchStorageUtil.Get<ILearningAssemblerProgress>(pawn.Map, pawn.Position).GetQuality;
+            if ( (var isqd=PatchStorageUtil.Get<ISetQualityDirectly>(pawn.Map, pawn.Position)) != null) {
+                __result = isqd.GetQuality(relevantSkill);
                 return false;
             }
             return true;
         }
     }
 
-    interface ILearningAssemblerProgress
+    interface ISetQualityDirectly
     {
-        QualityCategory GetQuality { get; }
+        QualityCategory GetQuality(SkillDef relevantSkill);
     }
 
 }

--- a/Source/ProjectRimFactory/Common/HarmonyPatches/Patch_GenRecipe_MakeRecipeProducts.cs
+++ b/Source/ProjectRimFactory/Common/HarmonyPatches/Patch_GenRecipe_MakeRecipeProducts.cs
@@ -134,21 +134,13 @@ namespace ProjectRimFactory.Common.HarmonyPatches
         }
     }
 
-    [HarmonyPatch(typeof(QualityUtility))]
-    [HarmonyPatch("GenerateQualityCreatedByPawn")]
-    [HarmonyPatch(new Type[] { typeof(Pawn), typeof(SkillDef) })]
+    [HarmonyPatch(typeof(QualityUtility),"GenerateQualityCreatedByPawn",new Type[] { typeof(Pawn), typeof(SkillDef)})]
     class Patch_GenRecipe_GenerateQualityCreatedByPawn
     {
         static bool Prefix(ref QualityCategory __result, Pawn pawn, SkillDef relevantSkill )
         {
-            Nullable<float> Speed = PatchStorageUtil.Get<ILearningAssemblerProgress>(pawn.Map, pawn.Position)?.ProductionSpeedFactor ?? null;
-            __result = 0;
-            if (Speed != null)
-            {
-                float centerX =  (float)Speed * 2f;
-                float num = Rand.Gaussian(centerX, 1.25f);
-                num = Mathf.Clamp(num, 0f, QualityUtility.AllQualityCategories.Count - 0.5f);
-                __result = (QualityCategory)((int)num);
+            if ( PatchStorageUtil.Get<ILearningAssemblerProgress>(pawn.Map, pawn.Position) != null) {
+                __result = PatchStorageUtil.Get<ILearningAssemblerProgress>(pawn.Map, pawn.Position).GetQuality;
                 return false;
             }
             return true;
@@ -157,7 +149,7 @@ namespace ProjectRimFactory.Common.HarmonyPatches
 
     interface ILearningAssemblerProgress
     {
-        float ProductionSpeedFactor { get; }
+        QualityCategory GetQuality { get; }
     }
 
 }

--- a/Source/ProjectRimFactory/Common/HarmonyPatches/Patch_GenRecipe_MakeRecipeProducts.cs
+++ b/Source/ProjectRimFactory/Common/HarmonyPatches/Patch_GenRecipe_MakeRecipeProducts.cs
@@ -139,7 +139,8 @@ namespace ProjectRimFactory.Common.HarmonyPatches
     {
         static bool Prefix(ref QualityCategory __result, Pawn pawn, SkillDef relevantSkill )
         {
-            if ( (var isqd=PatchStorageUtil.Get<ISetQualityDirectly>(pawn.Map, pawn.Position)) != null) {
+            ISetQualityDirectly isqd = PatchStorageUtil.Get<ISetQualityDirectly>(pawn.Map, pawn.Position);
+            if (isqd != null) {
                 __result = isqd.GetQuality(relevantSkill);
                 return false;
             }

--- a/Source/ProjectRimFactory/SAL3/Things/Assemblers/Building_ProgrammableAssembler.cs
+++ b/Source/ProjectRimFactory/SAL3/Things/Assemblers/Building_ProgrammableAssembler.cs
@@ -356,6 +356,11 @@ namespace ProjectRimFactory.SAL3.Things.Assemblers
             foreach (Thing thing in products)
             {
                 PostProcessRecipeProduct(thing);
+                CompQuality compQuality = thing.TryGetComp<CompQuality>();
+                if (compQuality != null)
+                {
+                    QualityUtility.SendCraftNotification(thing, buildingPawn);
+                }
                 thingQueue.Add(thing);
             }
             for (int i = 0; i < currentBillReport.selected.Count; i++)

--- a/Source/ProjectRimFactory/SAL3/Things/Assemblers/Building_ProgrammableAssembler.cs
+++ b/Source/ProjectRimFactory/SAL3/Things/Assemblers/Building_ProgrammableAssembler.cs
@@ -60,7 +60,7 @@ namespace ProjectRimFactory.SAL3.Things.Assemblers
             {
 
                 Pawn p = PawnGenerator.GeneratePawn(PRFDefOf.PRFSlavePawn, Faction.OfPlayer);
-                p.Name = new NameTriple("...", "SAL_Name".Translate(), "...");
+                p.Name = new NameTriple("...", Label ?? "SAL_Name".Translate(), "...");
                 //Assign skills
                 foreach (var s in p.skills.skills)
                 {

--- a/Source/ProjectRimFactory/SAL3/Things/Assemblers/Building_ProgrammableAssembler.cs
+++ b/Source/ProjectRimFactory/SAL3/Things/Assemblers/Building_ProgrammableAssembler.cs
@@ -356,11 +356,6 @@ namespace ProjectRimFactory.SAL3.Things.Assemblers
             foreach (Thing thing in products)
             {
                 PostProcessRecipeProduct(thing);
-                CompQuality compQuality = thing.TryGetComp<CompQuality>();
-                if (compQuality != null)
-                {
-                    QualityUtility.SendCraftNotification(thing, buildingPawn);
-                }
                 thingQueue.Add(thing);
             }
             for (int i = 0; i < currentBillReport.selected.Count; i++)

--- a/Source/ProjectRimFactory/SAL3/Things/Assemblers/Special/Building_Assembler_Learning.cs
+++ b/Source/ProjectRimFactory/SAL3/Things/Assemblers/Special/Building_Assembler_Learning.cs
@@ -61,7 +61,8 @@ namespace ProjectRimFactory.SAL3.Things.Assemblers.Special
             }
         }
 
-        [HarmonyPatch(typeof(Verse.GenRecipe), "PostProcessProduct")] /* there will be more here if finding MethodName by just its name is hard - I don't think this will be hard*/
+        //this patch prevents the execution of SendCraftNotification and all other calls the affect the quality. This is done caue the quality will be set with  ProjectRimFactory.SAL3.Things.Assemblers.Special.PostProcessRecipeProduct
+        [HarmonyPatch(typeof(Verse.GenRecipe), "PostProcessProduct")]
         class Patch_GenRecipe_PostProcessProduct
         {
             static bool Prefix(ref Thing __result, Thing product, RecipeDef recipeDef, Pawn worker)
@@ -75,25 +76,25 @@ namespace ProjectRimFactory.SAL3.Things.Assemblers.Special
                         {
                             Log.Error(string.Concat(recipeDef, " needs workSkill because it creates a product with a quality."));
                         }
-                        QualityCategory q = QualityUtility.GenerateQualityCreatedByPawn(worker, recipeDef.workSkill);
-                        compQuality.SetQuality(q, ArtGenerationContext.Colony);
+                        //QualityCategory q = QualityUtility.GenerateQualityCreatedByPawn(worker, recipeDef.workSkill);
+                        compQuality.SetQuality(0, ArtGenerationContext.Colony); //Set a placeholder Quality 
                         //QualityUtility.SendCraftNotification(product, worker);
                     }
                     CompArt compArt = product.TryGetComp<CompArt>();
                     if (compArt != null)
                     {
                         compArt.JustCreatedBy(worker);
-                        if (compQuality != null && (int)compQuality.Quality >= 4)
-                        {
-                            TaleRecorder.RecordTale(TaleDefOf.CraftedArt, worker, product);
-                        }
+                        //if (compQuality != null && (int)compQuality.Quality >= 4)
+                        //{
+                        //    TaleRecorder.RecordTale(TaleDefOf.CraftedArt, worker, product);
+                        //}
                     }
                     if (product.def.Minifiable)
                     {
                         product = product.MakeMinified();
                     }
                     __result = product;
-                    return false; // do not make notifications for Assemblers
+                    return false; // do not run vanilla
                 }
                 return true; // run vanilla
             }

--- a/Source/ProjectRimFactory/SAL3/Things/Assemblers/Special/Building_Assembler_Learning.cs
+++ b/Source/ProjectRimFactory/SAL3/Things/Assemblers/Special/Building_Assembler_Learning.cs
@@ -76,8 +76,8 @@ namespace ProjectRimFactory.SAL3.Things.Assemblers.Special
                         {
                             Log.Error(string.Concat(recipeDef, " needs workSkill because it creates a product with a quality."));
                         }
-                        //QualityCategory q = QualityUtility.GenerateQualityCreatedByPawn(worker, recipeDef.workSkill);
-                        compQuality.SetQuality(0, ArtGenerationContext.Colony); //Set a placeholder Quality 
+                        QualityCategory q = QualityUtility.GenerateQualityCreatedByPawn(worker, recipeDef.workSkill);
+                        compQuality.SetQuality(q, ArtGenerationContext.Colony); 
                         //QualityUtility.SendCraftNotification(product, worker);
                     }
                     CompArt compArt = product.TryGetComp<CompArt>();

--- a/Source/ProjectRimFactory/SAL3/Things/Assemblers/Special/Building_Assembler_Learning.cs
+++ b/Source/ProjectRimFactory/SAL3/Things/Assemblers/Special/Building_Assembler_Learning.cs
@@ -11,7 +11,7 @@ using ProjectRimFactory.Common.HarmonyPatches;
 
 namespace ProjectRimFactory.SAL3.Things.Assemblers.Special
 {
-    public class Building_Assembler_Learning : Building_SmartAssembler , ILearningAssemblerProgress
+    public class Building_Assembler_Learning : Building_SmartAssembler , ISetQualityDirectly
     {
         public float FactorOffset
         {
@@ -29,17 +29,13 @@ namespace ProjectRimFactory.SAL3.Things.Assemblers.Special
             }
         }
 
-        //Calculate the Item Quality based on the ProductionSpeedFactor (Used by the Harmony Patch)
-        QualityCategory ILearningAssemblerProgress.GetQuality
+        //Calculate the Item Quality based on the ProductionSpeedFactor (Used by the Harmony Patch; see Patch_GenRecipe_MakeRecipeProducts.cs)
+        QualityCategory ISetQualityDirectly.GetQuality(SkillDef relevantSkill)
         {
-            get
-            {
-                float centerX = ProductionSpeedFactor * 2f;
-                float num = Rand.Gaussian(centerX, 1.25f);
-                num = Mathf.Clamp(num, 0f, QualityUtility.AllQualityCategories.Count - 0.5f);
-                return (QualityCategory)((int)num);
-
-            }
+            float centerX = ProductionSpeedFactor * 2f;
+            float num = Rand.Gaussian(centerX, 1.25f);
+            num = Mathf.Clamp(num, 0f, QualityUtility.AllQualityCategories.Count - 0.5f);
+            return (QualityCategory)((int)num);
         }
 
         public override void Tick()

--- a/Source/ProjectRimFactory/SAL3/Things/Assemblers/Special/Building_Assembler_Learning.cs
+++ b/Source/ProjectRimFactory/SAL3/Things/Assemblers/Special/Building_Assembler_Learning.cs
@@ -29,8 +29,18 @@ namespace ProjectRimFactory.SAL3.Things.Assemblers.Special
             }
         }
 
-        //Used to Provide the ProductionSpeedFactor to the Harmony Patch for our increasing quality code
-        float ILearningAssemblerProgress.ProductionSpeedFactor => ProductionSpeedFactor;
+        //Calculate the Item Quality based on the ProductionSpeedFactor (Used by the Harmony Patch)
+        QualityCategory ILearningAssemblerProgress.GetQuality
+        {
+            get
+            {
+                float centerX = ProductionSpeedFactor * 2f;
+                float num = Rand.Gaussian(centerX, 1.25f);
+                num = Mathf.Clamp(num, 0f, QualityUtility.AllQualityCategories.Count - 0.5f);
+                return (QualityCategory)((int)num);
+
+            }
+        }
 
         public override void Tick()
         {


### PR DESCRIPTION
resolves #123 

@lilwhitemouse some points from my side:

- I would have preferred to patch `public static QualityCategory GenerateQualityCreatedByPawn(Pawn pawn, SkillDef relevantSkill)` but and call `public QualityCategory GetRandomProductionQuality()` from there but i dont know how to get the correct instance of `Building_Assembler_Learning` for the calculation
- probably should move the patch to another file any suggestions?