### PR TITLE
fixed CircleRange ignoring building size

### DIFF
--- a/Source/ProjectRimFactory/Common/CompPowerWorkSetting.cs
+++ b/Source/ProjectRimFactory/Common/CompPowerWorkSetting.cs
@@ -296,7 +296,7 @@ namespace ProjectRimFactory.Common
     {
         public IEnumerable<IntVec3> RangeCells(IntVec3 center, Rot4 rot, ThingDef thingDef, float range)
         {
-            return GenRadial.RadialCellsAround(center, range, true);
+            return GenRadial.RadialCellsAround(center, range + Mathf.Max(thingDef.size.x, thingDef.size.z) - 1, true);
         }
 
         public string ToText()


### PR DESCRIPTION
resolves #234 

@zymex22 This should resolve the issues.

if the building in not symmetrical I'm using the largest direction for the size calculation