### PR TITLE
enhanced fix for #256

### DIFF
--- a/Source/ProjectRimFactory/Drones/Building_DroneStation.cs
+++ b/Source/ProjectRimFactory/Drones/Building_DroneStation.cs
@@ -148,7 +148,7 @@ namespace ProjectRimFactory.Drones
             }
         }
 
-        
+        protected CompRefuelable refuelableComp;
 
         private List<SkillRecord> droneSkillsRecord = new List<SkillRecord>();
 
@@ -306,6 +306,7 @@ namespace ProjectRimFactory.Drones
         {
             base.PostMake();
             extension = def.GetModExtension<DefModExtension_DroneStation>();
+            refuelableComp = GetComp<CompRefuelable>();
         }
 
         private MapTickManager mapManager;
@@ -317,6 +318,7 @@ namespace ProjectRimFactory.Drones
         {
             base.SpawnSetup(map, respawningAfterLoad);
             this.mapManager = map.GetComponent<MapTickManager>();
+            refuelableComp = GetComp<CompRefuelable>();
             extension = def.GetModExtension<DefModExtension_DroneStation>();
             //Setup Allowd Area
             //Enssuring that Update_droneAllowedArea_forDrones() is run resolves #224 (May need to add a diffrent check)
@@ -504,6 +506,11 @@ namespace ProjectRimFactory.Drones
             if (WorkSettings == null) //Need for Compatibility with older saves
             {
                 WorkSettings = new Dictionary<WorkTypeDef, bool>();
+            }
+            //init refuelableComp after a Load
+            if (refuelableComp == null)
+            {
+                refuelableComp = this.GetComp<CompRefuelable>();
             }
 
 

--- a/Source/ProjectRimFactory/Drones/Building_DroneStationRefuelable.cs
+++ b/Source/ProjectRimFactory/Drones/Building_DroneStationRefuelable.cs
@@ -11,35 +11,20 @@ namespace ProjectRimFactory.Drones
 {
     public class Building_DroneStationRefuelable : Building_WorkGiverDroneStation
     {
-        protected CompRefuelable refuelableComp;
-
-
         public override void PostMake()
         {
             base.PostMake();
-
-            refuelableComp = GetComp<CompRefuelable>();
+            //Load the initial Drone Count. This must not happen on each load
             refuelableComp.Refuel(extension.GetDronesOnSpawn(refuelableComp));
-        }
-        public override void SpawnSetup(Map map, bool respawningAfterLoad)
-        {
-            //this needs to be called before base.SpawnSetup for the init implementation of droneSkillsRecord in Building_DroneStation
-            refuelableComp = GetComp<CompRefuelable>(); 
-
-            base.SpawnSetup(map, respawningAfterLoad);
         }
         public override int DronesLeft
         {
             get
             {
-                //needed as SpawnSetup is not called if the building is Minified
-                if (refuelableComp == null)
-                {
-                    refuelableComp = GetComp<CompRefuelable>();
-                }
                 return Mathf.RoundToInt(refuelableComp.Fuel) - spawnedDrones.Count;
             }
         }
+
         public override void Notify_DroneLost()
         {
             refuelableComp.ConsumeFuel(1);


### PR DESCRIPTION
Bases on some feedback from @lilwhitemouse I moved `CompRefuelable` to Building_DroneStation

The init of `CompRefuelable refuelableComp` is also moved to `public override void ExposeData()`

based on some Analysis of RW Code this is the earliest point possible to load Components _(even for Minified things)_.

@zymex22 small second test cant hurt. this should be better then the initial fix of #256 (provided with #260 )