### PR TITLE
Added support for the Art Counter

### DIFF
--- a/Source/ProjectRimFactory/Common/HarmonyPatches/UpdateResourceCountsPatch.cs
+++ b/Source/ProjectRimFactory/Common/HarmonyPatches/UpdateResourceCountsPatch.cs
@@ -17,7 +17,35 @@ namespace ProjectRimFactory.Common.HarmonyPatches
     }
 
 
-    //Art & maybe other things too need a patch for public virtual int CountProducts(Bill_Production bill)
+    //Art & maybe other things too need a seperate patch
+    [HarmonyPatch(typeof(RecipeWorkerCounter), "CountProducts")]
+    class Patch_CountProducts_AssemblerQueue
+    {
+
+        static void Postfix(RecipeWorkerCounter __instance,ref int __result, Bill_Production bill)
+        {
+            if (bill.includeFromZone == null) {
+                int i = 0;
+                ThingDef targetDef = __instance.recipe.products[0].thingDef;
+
+
+                for (i = 0; i < PRFGameComponent.AssemblerQueue.Count; i++)
+                {
+                    foreach (Thing heldThing in PRFGameComponent.AssemblerQueue[i].GetThingQueue())
+                    {
+                        Thing innerIfMinified = heldThing.GetInnerIfMinified();
+                        if (innerIfMinified.def == targetDef)
+                        {
+
+                            __result += innerIfMinified.stackCount;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
 
     [HarmonyPatch(typeof(ResourceCounter), "UpdateResourceCounts")]
     class Patch_UpdateResourceCounts_AssemblerQueue


### PR DESCRIPTION
This resolves an oversight in the fix(#271) for #168

Art is not counted by `UpdateResourceCounts` but is instead Count via `RecipeWorkerCounter.CountProducts(bill)`
This adds a Harmony Patch so that things counted by `CountProducts` include things in the Assembler Queue.

Added @lilwhitemouse to check if the Patch is fine or if it should be enhanced.