### PR TITLE
resolved #336 by fixing my oversight and deleating the Zone on despawn

### DIFF
--- a/Source/ProjectRimFactory/Drones/Building_DroneStation.cs
+++ b/Source/ProjectRimFactory/Drones/Building_DroneStation.cs
@@ -410,7 +410,14 @@ namespace ProjectRimFactory.Drones
             {
                 drones[i].Destroy();
             }
+            if (droneAllowedArea != null)
+            {
+                //Deleate the old Zone
+                droneAllowedArea.Delete();
+            }
+            
             droneAllowedArea = null;
+
 
         }
 


### PR DESCRIPTION
resolves #336 

Will ensure that Zones are deleted on spawn. preventing unused Zones from clogging the save file.

_Note: this will not delete already existing zones. for affected users a manual cleanup of the save file is required (just delete the zones form the xml save)_