### PR TITLE
Fixed rotated drawing for small crates

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Storage.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Storage.xml
@@ -58,7 +58,6 @@
       <texPath>Storage/Wood_Crate6</texPath>
       <drawSize>(2.8,1.3)</drawSize>
       <color>(133,97,67,256)</color>      <!-- used to set wood color because stuffed isnt used -->
-      <drawRotated>false</drawRotated>      <!-- Can rotate ingame without rotate texture, will flip horizontaly only. -->
     </graphicData>
     <statBases>
       <Mass>10</Mass>
@@ -170,7 +169,6 @@
       <texPath>Storage/Steel_Crate</texPath>
       <drawSize>(2.8,1.3)</drawSize>
       <color>(102,102,105,256)</color>
-      <drawRotated>false</drawRotated>      <!-- Can rotate ingame without rotate texture, will flip horizontaly only. -->
     </graphicData>
     <statBases>
       <Mass>10</Mass>


### PR DESCRIPTION
With `<drawRotated>false</drawRotated>` (xpath of `ThingDef/graphicData/drawRotated`) the small crates are drawn distorted when rotated (stretched vertically, squished horizontally). Obviously, this makes the texture a little ugly but it's even worse when applied to a texture with less symmetry (like Neceros' PRF patch that adds little vaults).