### PR TITLE
Fixes to jewelry patch

### DIFF
--- a/Patches/Drill patches/jewelry.xml
+++ b/Patches/Drill patches/jewelry.xml
@@ -10,24 +10,8 @@
 			<success>Always</success>
 			<operations>
 				<!-- Remove/Exclude ores from standard chances and Bills on miners -->
-				<li Class="PatchOperationAdd">					<!-- T1 miner Remove from standard chance -->
-					<xpath>/Defs/ThingDef[defName="PRF_DeepQuarry_mkI"]/modExtensions/li[@Class="ProjectRimFactory.Common.ModExtension_Miner"]/excludeOres</xpath>
-					<value>
-						<li>Sapphire</li>
-						<li>Ruby</li>
-						<li>Diamond</li>
-					</value>
-				</li>
-				<li Class="PatchOperationAdd">					<!-- T2 miner Remove from standard chance -->
-					<xpath>/Defs/ThingDef[defName="PRF_DeepQuarry_mkII"]/modExtensions/li[@Class="ProjectRimFactory.Common.ModExtension_Miner"]/excludeOres</xpath>
-					<value>
-						<li>Sapphire</li>
-						<li>Ruby</li>
-						<li>Diamond</li>
-					</value>
-				</li>
-				<li Class="PatchOperationAdd">					<!-- T3 miner Remove from Bill list -->
-					<xpath>/Defs/ThingDef[defName="PRF_BillTypeMiner_I"]/modExtensions/li[@Class="ProjectRimFactory.Common.ModExtension_Miner"]/excludeOres</xpath>
+				<li Class="PatchOperationAdd">					<!-- T1-T3 miner Remove from standard chance -->
+					<xpath>/Defs/ThingDef[starts-with(defName, "PRF_DeepQuarry_mk") or defName="PRF_BillTypeMiner_I"]/modExtensions/li[@Class="ProjectRimFactory.Common.ModExtension_Miner"]/excludeOres</xpath>
 					<value>
 						<li>Sapphire</li>
 						<li>Ruby</li>
@@ -52,7 +36,7 @@
 					</value>
 				</li>
 				<li Class="PatchOperationAdd">					<!-- T3 miner Add it as a special extra chance -->
-					<xpath>/Defs/ThingDef[defName="PRF_BillTypeMiner_I"]/modExtensions/li[@Class="ProjectRimFactory.Common.ModExtension_ModifyProduct"]/bonusYields</xpath>
+					<xpath>/Defs/ThingDef[defName="PRF_DeepQuarry_mkIII" or defName="PRF_BillTypeMiner_I"]/modExtensions/li[@Class="ProjectRimFactory.Common.ModExtension_ModifyProduct"]/bonusYields</xpath>
 					<value>
 						<Sapphire Weight="0.45" Count="20" />
 						<Ruby Weight="0.4" Count="20" />


### PR DESCRIPTION
Previously, this was excluding from dq_mki, dq_mkii, and billtypeminer_i. I _think_ the intent was to exclude from all and give them a small chance, based on tier, of getting those valuable gemstone ores (I inferred this from the miners XML). If so, this is a good patch to do so. If I misunderstood the intent, it is not. Let me know and I can correct this patch and resubmit.

Also of note, `starts-with(defName, "PRF_DeepQuarry_mk") or defName="PRF_BillTypeMiner_I"` lets you save 3 `PatchOperationAdd` nodes. Not going to have much performance impact but applied to a large enough patching project, the pattern could add up.

Also, let me know if the "no newline at end of file" is an explicit standard or just happenstance. I can follow it with a couple of changes.