### PR TITLE
Fix hoppers pulling from underground belts

### DIFF
--- a/Source/ProjectRimFactory/Common/GatherThingsUtility.cs
+++ b/Source/ProjectRimFactory/Common/GatherThingsUtility.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using ProjectRimFactory.AutoMachineTool;
 using ProjectRimFactory.Common;
 using Verse;
 using RimWorld;
@@ -31,6 +32,8 @@ namespace ProjectRimFactory {
                 Thing t = thingList[i];
                 if (t is Building && t is IThingHolder holder) {
                     if (holder.GetDirectlyHeldThings() is ThingOwner<Thing> owner) {
+                        if (t is Building_BeltConveyor belt && belt.IsUnderground) continue;
+
                         for (int j = owner.InnerListForReading.Count - 1; j >= 0; j--) {
                             yield return owner.InnerListForReading[j];
                         }

--- a/Source/ProjectRimFactory/Common/GatherThingsUtility.cs
+++ b/Source/ProjectRimFactory/Common/GatherThingsUtility.cs
@@ -40,7 +40,13 @@ namespace ProjectRimFactory
                 {
                     if (holder.GetDirectlyHeldThings() is ThingOwner<Thing> owner)
                     {
-                        if (t is Building_BeltConveyor belt && belt.IsUnderground) continue;
+                        switch (t)
+                        {
+                            // If the belt is underground or it's a connector to send items underground, skip it.
+                            case Building_BeltConveyor belt when belt.IsUnderground:
+                            case Building_BeltConveyorUGConnector _:
+                                continue;
+                        }
 
                         for (int j = owner.InnerListForReading.Count - 1; j >= 0; j--)
                         {

--- a/Source/ProjectRimFactory/Common/GatherThingsUtility.cs
+++ b/Source/ProjectRimFactory/Common/GatherThingsUtility.cs
@@ -5,15 +5,19 @@ using ProjectRimFactory.AutoMachineTool;
 using ProjectRimFactory.Common;
 using Verse;
 using RimWorld;
-namespace ProjectRimFactory {
-    public static class GatherThingsUtility {
+
+namespace ProjectRimFactory
+{
+    public static class GatherThingsUtility
+    {
         /// <summary>
         /// A list of cells that might be appropriate for a PRF building to gather input items from.
         ///   If the PRF building has a CompPowerWorkSetting comp, it uses that, otherwise
         ///   it defaults to all adjacent cells around the building.
         /// </summary>
         /// <param name="building">A building. Probably a PRF building. Probably one that makes things.</param>
-        public static IEnumerable<IntVec3> InputCells(this Building building) {
+        public static IEnumerable<IntVec3> InputCells(this Building building)
+        {
             return building.GetComp<CompPowerWorkSetting>()?.GetRangeCells() ?? GenAdj.CellsAdjacent8Way(building);
         }
 
@@ -25,20 +29,27 @@ namespace ProjectRimFactory {
         /// <returns>The items in cell <paramref name="c"/> for use.</returns>
         /// <param name="c">Cell</param>
         /// <param name="map">Map</param>
-        public static IEnumerable<Thing> AllThingsInCellForUse(this IntVec3 c, Map map, bool allowStorageZones = true) {
+        public static IEnumerable<Thing> AllThingsInCellForUse(this IntVec3 c, Map map, bool allowStorageZones = true)
+        {
             List<Thing> thingList = map.thingGrid.ThingsListAt(c);
             //Risk for duplicate entrys if a cell contins both a Item & a IThingHolder that holds said item
-            for (int i=thingList.Count-1; i>=0; i--) {
+            for (int i = thingList.Count - 1; i >= 0; i--)
+            {
                 Thing t = thingList[i];
-                if (t is Building && t is IThingHolder holder) {
-                    if (holder.GetDirectlyHeldThings() is ThingOwner<Thing> owner) {
+                if (t is Building && t is IThingHolder holder)
+                {
+                    if (holder.GetDirectlyHeldThings() is ThingOwner<Thing> owner)
+                    {
                         if (t is Building_BeltConveyor belt && belt.IsUnderground) continue;
 
-                        for (int j = owner.InnerListForReading.Count - 1; j >= 0; j--) {
+                        for (int j = owner.InnerListForReading.Count - 1; j >= 0; j--)
+                        {
                             yield return owner.InnerListForReading[j];
                         }
                     }
-                } else if (t.def.category == ThingCategory.Item) {
+                }
+                else if (t.def.category == ThingCategory.Item)
+                {
                     yield return t;
                 }
                 //This should support all other storage Buildings
@@ -51,7 +62,8 @@ namespace ProjectRimFactory {
                 }
             }
             //Pull from Storage Zones
-            if (allowStorageZones && c.GetZone(map) is Zone_Stockpile sz){
+            if (allowStorageZones && c.GetZone(map) is Zone_Stockpile sz)
+            {
                 foreach (Thing thing in sz.AllContainedThings.Where(t => t.def.category == ThingCategory.Item))
                 {
                     yield return thing;


### PR DESCRIPTION
Noticed smart hoppers were picking stuff up from underground belts, so some items would be instantly taken back after going through a puller. This was an issue when `PickupFromGround` was enabled.

Video:
https://user-images.githubusercontent.com/29930410/111091404-983ced00-8511-11eb-8a65-119311d7e228.mp4

Added a check for skipping items in underground belts and over-underground connectors.
Also reformatted the `GatherThingsUtility` file a bit if that's okay.
