### PR TITLE
#196 Added 10W Power Consumption per Drone

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Drones.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Drones.xml
@@ -103,9 +103,19 @@
         <initialConfigurableTargetFuelLevel>3</initialConfigurableTargetFuelLevel>
         <drawOutOfFuelOverlay>false</drawOutOfFuelOverlay>
       </li>
+      <li Class="ProjectRimFactory.Common.CompProperties_PowerWorkSetting">
+        <!-- Speed Settings -->
+        <floatrange_SpeedFactor>1~1</floatrange_SpeedFactor>
+        <powerPerStepSpeed>0</powerPerStepSpeed>
+        <powerStepFactor>1</powerStepFactor>
+        <!-- Range Settings -->
+        <floatrange_Range>0~0</floatrange_Range>
+        <powerPerStepRange>0</powerPerStepRange>
+        <allowManualRangeTypeChange>false</allowManualRangeTypeChange>
+        <rangeType>ProjectRimFactory.Common.RectRange</rangeType>
+      </li>
     </comps>
     <rotatable>false</rotatable>
-
     <placeWorkers>
       <li>ProjectRimFactory.Drones.PlaceWorker_DroneStation</li>
     </placeWorkers>

--- a/Source/ProjectRimFactory/Drones/Building_DroneStation.cs
+++ b/Source/ProjectRimFactory/Drones/Building_DroneStation.cs
@@ -137,7 +137,7 @@ namespace ProjectRimFactory.Drones
 
 
     [StaticConstructorOnStartup]
-    public abstract class Building_DroneStation : Building , IPowerSupplyMachineHolder , IDroneSeetingsITab, IPRF_SettingsContentLink
+    public abstract class Building_DroneStation : Building , IPowerSupplyMachineHolder , IDroneSeetingsITab, IPRF_SettingsContentLink, IAdditionalPowerConsumption
     {
         //Sleep Time List (Loaded on Spawn)
         public string[] cachedSleepTimeList;
@@ -182,6 +182,8 @@ namespace ProjectRimFactory.Drones
             }
 
         }
+
+        Dictionary<string, int> IAdditionalPowerConsumption.AdditionalPowerConsumption => new Dictionary<string, int> { { "Drone Count", (int)refuelableComp.Fuel * 10 } };
 
         private CompPowerWorkSetting compPowerWorkSetting;
 


### PR DESCRIPTION
resolves #196 

@zymex22 if the goal was to have this as a setting in XML please let me know and i will add this.
ATM adds a general 10W per drone for any station.

Ready for merge if nothing additional is required