### PR TITLE
#374 prevented pullers from stealing Items - They now only take none …

### DIFF
--- a/Source/ProjectRimFactory/AutoMachineTool/Building_ItemPuller.cs
+++ b/Source/ProjectRimFactory/AutoMachineTool/Building_ItemPuller.cs
@@ -116,6 +116,7 @@ namespace ProjectRimFactory.AutoMachineTool
             target = (this.Position + this.Rotation.Opposite.FacingCell).AllThingsInCellForUse(this.Map)
                         .Where(t => !t.IsForbidden(Faction.OfPlayer) || this.takeForbiddenItems)
                         .Where(t => this.settings.AllowedToAccept(t))
+                        .Where(t => !this.Map.reservationManager.AllReservedThings().Contains(t))
                         .FirstOrDefault(t => !this.IsLimit(t));
             if (target == null) return target;
             if (this.takeSingleItems) return (target.SplitOff(1));


### PR DESCRIPTION
resolves #374 

prevents pullers from stealing items.

@zymex22 @lilwhitemouse Unless there are any scenarios where we want Pullers to Steal items this is ready to merge