### PR TITLE
#347 added setting to forbid on placemement for all IPRF_Building(s)

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Storage.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Storage.xml
@@ -594,6 +594,9 @@
         <hideItems>true</hideItems>
       </li>
     </modExtensions>
+    <inspectorTabs>
+      <li>ProjectRimFactory.Common.ITab_ProductionSettings</li>
+    </inspectorTabs>
   </ThingDef>
   
 

--- a/Languages/English/Keyed/AllKeyed_Settings.xml
+++ b/Languages/English/Keyed/AllKeyed_Settings.xml
@@ -4,8 +4,10 @@
   <PRF_Settings_C_Lite_Header>Toggle PRF Lite Mode</PRF_Settings_C_Lite_Header>
   <PRF_Settings_C_Lite_Label>PRF Lite Mode</PRF_Settings_C_Lite_Label>
   <PRF_Settings_C_Lite_ToolTip>Toggle between PRF Lite and PRF Core. \nUnchecked means PRF Core \nChecked means PRF Lite</PRF_Settings_C_Lite_ToolTip>
-
-
+  
+  <PRF.Common.ForbidOnPlacingDefault>Forbit items on Placment</PRF.Common.ForbidOnPlacingDefault>
+  <PRF.Common.ForbidOnPlacingDefaultDesc>Toggle this to forbid items on placement</PRF.Common.ForbidOnPlacingDefaultDesc>
+  
   <PRF.Settings.RequireReboot>Changes require reboot to apply the setting.</PRF.Settings.RequireReboot>
   <PRF.Settings.Select>Select</PRF.Settings.Select>
   <PRF.Settings.TopMessage><![CDATA[<size=20>All setting changes <b><i><color=red>require a restart</color></i></b></size>]]></PRF.Settings.TopMessage>

--- a/Languages/English/Keyed/AllKeyed_Settings.xml
+++ b/Languages/English/Keyed/AllKeyed_Settings.xml
@@ -5,7 +5,7 @@
   <PRF_Settings_C_Lite_Label>PRF Lite Mode</PRF_Settings_C_Lite_Label>
   <PRF_Settings_C_Lite_ToolTip>Toggle between PRF Lite and PRF Core. \nUnchecked means PRF Core \nChecked means PRF Lite</PRF_Settings_C_Lite_ToolTip>
   
-  <PRF.Common.ForbidOnPlacingDefault>Forbit items on Placment</PRF.Common.ForbidOnPlacingDefault>
+  <PRF.Common.ForbidOnPlacingDefault>Forbid items on Placment</PRF.Common.ForbidOnPlacingDefault>
   <PRF.Common.ForbidOnPlacingDefaultDesc>Toggle this to forbid items on placement</PRF.Common.ForbidOnPlacingDefaultDesc>
   
   <PRF.Settings.RequireReboot>Changes require reboot to apply the setting.</PRF.Settings.RequireReboot>

--- a/Source/ProjectRimFactory/AutoMachineTool/Building_Base.cs
+++ b/Source/ProjectRimFactory/AutoMachineTool/Building_Base.cs
@@ -503,5 +503,6 @@ namespace ProjectRimFactory.AutoMachineTool
                     return p;
                 }).ToList();
         }
+
     }
 }

--- a/Source/ProjectRimFactory/Common/IPRF_Building.cs
+++ b/Source/ProjectRimFactory/Common/IPRF_Building.cs
@@ -35,6 +35,7 @@ namespace ProjectRimFactory.Common {
         /// </summary>
         /// <returns><c>true</c>, if, on placing, thing should be forbidden, <c>false</c> otherwise.</returns>
         bool ForbidOnPlacing(Thing t);
+        bool ForbidOnPlacingDefault { get; set; }
         bool ObeysStorageFilters { get; }
         bool OutputToEntireStockpile { get; }
         void EffectOnPlaceThing(Thing t);

--- a/Source/ProjectRimFactory/Common/ITab_ProductionSettings.cs
+++ b/Source/ProjectRimFactory/Common/ITab_ProductionSettings.cs
@@ -181,6 +181,16 @@ namespace ProjectRimFactory.Common
                     }
                 }
             }
+            if (ShowForbidOnPlacingSetting)
+            {
+                if (doneSection) list.GapLine();
+                doneSection = true;
+                bool tmpB = pRF_Building.ForbidOnPlacingDefault;
+                list.CheckboxLabeled("PRF.Common.ForbidOnPlacingDefault".Translate(), ref tmpB,
+                    "PRF.Common.ForbidOnPlacingDefaultDesc".Translate());
+                if (tmpB != pRF_Building.ForbidOnPlacingDefault)
+                    pRF_Building.ForbidOnPlacingDefault = tmpB;
+            }
             if (Machine != null) {
                 if (doneSection) list.GapLine();
                 doneSection = true;
@@ -268,16 +278,7 @@ namespace ProjectRimFactory.Common
 
             }
 
-            if (ShowForbidOnPlacingSetting)
-            {
-                if (doneSection) list.GapLine();
-                doneSection = true;
-                bool tmpB = pRF_Building.ForbidOnPlacingDefault;
-                list.CheckboxLabeled("PRF.Common.ForbidOnPlacingDefault".Translate(), ref tmpB,
-                    "PRF.Common.ForbidOnPlacingDefaultDesc".Translate());
-                if (tmpB != pRF_Building.ForbidOnPlacingDefault)
-                    pRF_Building.ForbidOnPlacingDefault = tmpB;
-            }
+            
             
             
             list.Gap();

--- a/Source/ProjectRimFactory/Common/ITab_ProductionSettings.cs
+++ b/Source/ProjectRimFactory/Common/ITab_ProductionSettings.cs
@@ -63,7 +63,7 @@ namespace ProjectRimFactory.Common
 
         public override bool IsVisible {
             get {
-                return showITabTests.FirstOrDefault(t=>(t!=null && t(SelThing))) != null || ShowProductLimt || ShowOutputToEntireStockpile || ShowObeysStorageFilter || ShowAdditionalSettings || ShowAreaSelectButton;
+                return showITabTests.FirstOrDefault(t=>(t!=null && t(SelThing))) != null || ShowProductLimt || ShowOutputToEntireStockpile || ShowObeysStorageFilter || ShowAdditionalSettings || ShowAreaSelectButton || ShowForbidOnPlacingSetting;
             }
         }
         bool ShowProductLimt => Machine != null;
@@ -74,6 +74,8 @@ namespace ProjectRimFactory.Common
         bool ShowObeysStorageFilter => (PRFB != null &&
                 (PRFB.SettingsOptions & PRFBSetting.optionObeysStorageFilters) > 0) &&
                 !(PRFB is IBeltConveyorLinkable belt && !belt.CanSendToLevel(ConveyorLevel.Ground));
+
+        bool ShowForbidOnPlacingSetting => pRF_Building != null;
 
         bool ShowRangeTypeSelectorButton => ShowAreaSelectButton && compPropertiesPowerWork != null && compPropertiesPowerWork.Props.allowManualRangeTypeChange;
 
@@ -91,6 +93,7 @@ namespace ProjectRimFactory.Common
 
         private IPRF_SettingsContentLink pRF_SettingsContent { get => this.SelThing as IPRF_SettingsContentLink; }
 
+        private IPRF_Building pRF_Building { get => this.SelThing as IPRF_Building; }
 
         private PRF_Building PRFB { get => this.SelThing as PRF_Building; }
 
@@ -107,6 +110,7 @@ namespace ProjectRimFactory.Common
             if (ShowProductLimt) winSize.y += 270f;
             if (ShowOutputToEntireStockpile) winSize.y += 100f;
             if (ShowObeysStorageFilter) winSize.y += 70f;
+            if (ShowForbidOnPlacingSetting) winSize.y += 30f;
             for (int i = 0; i < showITabTests.Count; i++) {
                 if (showITabTests[i]?.Invoke(this.SelThing) == true) {
                     winSize.y += (extraHeightRequests[i]?.Invoke(this.SelThing) ?? 0);
@@ -120,7 +124,7 @@ namespace ProjectRimFactory.Common
             if(ShowRangeTypeSelectorButton) winSize.y += 100f;
 
             float maxHeight = 900f;
-            float minHeight = 50f; // if this starts too large, the window will be too high
+            float minHeight = 70f; // if this starts too large, the window will be too high
             float inspectWindowHeight = 268f; // Note: at least one mod makes this larger - this may not be enough.
             if (UI.screenHeight > minHeight - inspectWindowHeight) maxHeight = (float)UI.screenHeight - inspectWindowHeight;
             winSize.y = Mathf.Clamp(winSize.y, minHeight, maxHeight); //Support for lower Resulutions (With that the Tab should always fit on the screen) 
@@ -264,6 +268,16 @@ namespace ProjectRimFactory.Common
 
             }
 
+            if (ShowForbidOnPlacingSetting)
+            {
+                if (doneSection) list.GapLine();
+                doneSection = true;
+                bool tmpB = pRF_Building.ForbidOnPlacingDefault;
+                list.CheckboxLabeled("PRF.Common.ForbidOnPlacingDefault".Translate(), ref tmpB,
+                    "PRF.Common.ForbidOnPlacingDefaultDesc".Translate());
+                if (tmpB != pRF_Building.ForbidOnPlacingDefault)
+                    pRF_Building.ForbidOnPlacingDefault = tmpB;
+            }
             
             
             list.Gap();

--- a/Source/ProjectRimFactory/Common/PRF_Building.cs
+++ b/Source/ProjectRimFactory/Common/PRF_Building.cs
@@ -17,8 +17,14 @@ namespace ProjectRimFactory.Common
         public virtual void EffectOnPlaceThing(Thing t) { }
         public virtual void EffectOnAcceptThing(Thing t) { }
 
-        //TODO: make this like the next two?
-        public virtual bool ForbidOnPlacing(Thing t) => false;
+        public virtual bool ForbidOnPlacing(Thing t) => ForbidOnPlacingDefault;
+
+        public virtual bool ForbidOnPlacingDefault
+        {
+            get => forbidOnPlacingDefault;
+            set => forbidOnPlacingDefault = value;
+        }
+
         public virtual bool ObeysStorageFilters {
             get => obeysStorageFilters;
             set => obeysStorageFilters = value;
@@ -35,10 +41,13 @@ namespace ProjectRimFactory.Common
         protected bool outputToEntireStockpile=false;
         protected bool obeysStorageFilters = true;
 
+        protected bool forbidOnPlacingDefault = false;
+
         public override void ExposeData() {
             base.ExposeData();
             Scribe_Values.Look(ref outputToEntireStockpile, "PRFOutputToEntireStockpile", false);
             Scribe_Values.Look(ref obeysStorageFilters, "PRFObeysStorageFilters", true);
+            Scribe_Values.Look(ref forbidOnPlacingDefault, "PRFForbidOnPlacingDefault", true);
         }
     }
     [Flags] // PRF Building Settinsg

--- a/Source/ProjectRimFactory/Storage/Building_ItemSlide.cs
+++ b/Source/ProjectRimFactory/Storage/Building_ItemSlide.cs
@@ -14,6 +14,14 @@ namespace ProjectRimFactory.Storage
     {
         public IEnumerable<Thing> AvailableThings => throw new NotImplementedException();
 
+        public virtual bool ForbidOnPlacingDefault
+        {
+            get => forbidOnPlacingDefault;
+            set => forbidOnPlacingDefault = value;
+        }
+
+        protected bool forbidOnPlacingDefault = false;
+
         public bool ObeysStorageFilters => false;
 
         public bool OutputToEntireStockpile => false;
@@ -46,7 +54,7 @@ namespace ProjectRimFactory.Storage
         {
             if (outputCell.GetThingList(Map).Where(type => type is IPRF_Building || type is Building_StorageUnitIOBase || type is Building_MassStorageUnit).Any<Thing>())
             {
-                return false;
+                return ForbidOnPlacingDefault;
             }
             else
             {


### PR DESCRIPTION
resolves #347

adds a Checkbox in the the Settings tab of all `IPRF_Building`s to forbid the item on placement.
This affects:
- Belts
- Pullers
- item Chute
- Assemblers
_maybe more if we add the tab for them_

@zymex22 please test before merge.