### PR TITLE
Fix typo in Building_StorageUnitIOPort.cs

### DIFF
--- a/Source/ProjectRimFactory/Storage/Building_StorageUnitIOPort.cs
+++ b/Source/ProjectRimFactory/Storage/Building_StorageUnitIOPort.cs
@@ -102,7 +102,7 @@ namespace ProjectRimFactory.Storage
         {
             get
             {
-                if (IOMode == StorageIOMode.Output && outputSettings.useMax)
+                if (IOMode == StorageIOMode.Output && OutputSettings.useMax)
                 {
                     //Only get currentItem if needed
                     Thing currentItem = WorkPosition.GetFirstItem(Map);


### PR DESCRIPTION
A typo was likely causing NullReferenceException errors in my game.
This fix was not tested beyond "hey the NullReferenceException errors disappeared afterwards".