### PR TITLE
Load PRF after Tab-Sorting

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -41,6 +41,7 @@
     <li>historic.IndustrialRollers</li>
     <li>essecoisa.Floored</li>
     <li>vanillaexpanded.achievements</li>
+    <li>Mlie.TabSorting</li>
   </loadAfter>
   <incompatibleWith>
   </incompatibleWith>


### PR DESCRIPTION
Loading PRF after the Tab-sorting mod (https://steamcommunity.com/sharedfiles/filedetails/?id=2138635288) creates these errors: https://gist.github.com/HugsLibRecordKeeper/4a69fea32a14eb521d29bdaea20aa9d9#file-output_log-txt-L97-L101

PRF should be loaded after Tab-Sorting.