### PR TITLE
Fix case of IOPort not updating

### DIFF
--- a/Source/ProjectRimFactory/Storage/Building_StorageUnitIOPort.cs
+++ b/Source/ProjectRimFactory/Storage/Building_StorageUnitIOPort.cs
@@ -266,7 +266,7 @@ namespace ProjectRimFactory.Storage
                                                                     OutputSettings.SatisfiesMax(currentItem.stackCount, currentItem.def.stackLimit));
                 if (boundStorageUnit != null && boundStorageUnit.CanReceiveIO)
                 {
-                    if (storageSlotAvailable && OutputSettings.min <= OutputSettings.max)
+                    if (storageSlotAvailable && (!OutputSettings.useMin || !OutputSettings.useMax || OutputSettings.min <= OutputSettings.max))
                     {
                         List<Thing> itemCandidates = new List<Thing>(from Thing t in boundStorageUnit.StoredItems where settings.AllowedToAccept(t) select t); // ToList very important - evaluates enumerable
                         if (ItemsThatSatisfyMin(itemCandidates, currentItem).Any())
@@ -482,7 +482,7 @@ namespace ProjectRimFactory.Storage
                                                                     OutputSettings.SatisfiesMax(currentItem.stackCount, currentItem.def.stackLimit));
                 if (boundStorageUnit != null && boundStorageUnit.CanReceiveIO)
                 {
-                    if (storageSlotAvailable && OutputSettings.min <= OutputSettings.max)
+                    if (storageSlotAvailable && (!OutputSettings.useMin || !OutputSettings.useMax || OutputSettings.min <= OutputSettings.max))
                     {
                         List<Thing> itemCandidates = new List<Thing>(from Thing t in boundStorageUnit.StoredItems where settings.AllowedToAccept(t) select t); // ToList very important - evaluates enumerable
                         if (ItemsThatSatisfyMin(itemCandidates, currentItem).Any())

--- a/Source/ProjectRimFactory/Storage/Building_StorageUnitIOPort.cs
+++ b/Source/ProjectRimFactory/Storage/Building_StorageUnitIOPort.cs
@@ -266,7 +266,7 @@ namespace ProjectRimFactory.Storage
                                                                     OutputSettings.SatisfiesMax(currentItem.stackCount, currentItem.def.stackLimit));
                 if (boundStorageUnit != null && boundStorageUnit.CanReceiveIO)
                 {
-                    if (storageSlotAvailable && (!OutputSettings.useMin || !OutputSettings.useMax || OutputSettings.min <= OutputSettings.max))
+                    if (storageSlotAvailable)
                     {
                         List<Thing> itemCandidates = new List<Thing>(from Thing t in boundStorageUnit.StoredItems where settings.AllowedToAccept(t) select t); // ToList very important - evaluates enumerable
                         if (ItemsThatSatisfyMin(itemCandidates, currentItem).Any())
@@ -482,7 +482,7 @@ namespace ProjectRimFactory.Storage
                                                                     OutputSettings.SatisfiesMax(currentItem.stackCount, currentItem.def.stackLimit));
                 if (boundStorageUnit != null && boundStorageUnit.CanReceiveIO)
                 {
-                    if (storageSlotAvailable && (!OutputSettings.useMin || !OutputSettings.useMax || OutputSettings.min <= OutputSettings.max))
+                    if (storageSlotAvailable)
                     {
                         List<Thing> itemCandidates = new List<Thing>(from Thing t in boundStorageUnit.StoredItems where settings.AllowedToAccept(t) select t); // ToList very important - evaluates enumerable
                         if (ItemsThatSatisfyMin(itemCandidates, currentItem).Any())

--- a/Source/ProjectRimFactory/Storage/UI/Dialog_OutputMinMax.cs
+++ b/Source/ProjectRimFactory/Storage/UI/Dialog_OutputMinMax.cs
@@ -72,7 +72,7 @@ namespace ProjectRimFactory.Storage.UI
             }
             if (outputSettings.max < outputSettings.min)
             {
-                maxBufferString = outputSettings.min.ToString();
+                maxBufferString = minBufferString;
             }
             list.Gap();
             list.CheckboxLabeled("SmartHopper_Maximum_Label".Translate(), ref outputSettings.useMax, outputSettings.maxTooltip.Translate());
@@ -90,7 +90,7 @@ namespace ProjectRimFactory.Storage.UI
             }
             if (outputSettings.min > outputSettings.max)
             { 
-                minBufferString = outputSettings.max.ToString();
+                minBufferString = maxBufferString;
             }
             list.End();
         }

--- a/Source/ProjectRimFactory/Storage/UI/Dialog_OutputMinMax.cs
+++ b/Source/ProjectRimFactory/Storage/UI/Dialog_OutputMinMax.cs
@@ -70,6 +70,10 @@ namespace ProjectRimFactory.Storage.UI
                 Text.Anchor = anchorBuffer;
                 Widgets.TextFieldNumeric(rectRight, ref outputSettings.min, ref minBufferString, 0);
             }
+            if (outputSettings.max < outputSettings.min)
+            {
+                maxBufferString = outputSettings.min.ToString();
+            }
             list.Gap();
             list.CheckboxLabeled("SmartHopper_Maximum_Label".Translate(), ref outputSettings.useMax, outputSettings.maxTooltip.Translate());
             list.Gap();
@@ -83,6 +87,10 @@ namespace ProjectRimFactory.Storage.UI
                 Widgets.Label(rectLeft, "SmartHopper_MaximumKeyword".Translate());
                 Text.Anchor = anchorBuffer;
                 Widgets.TextFieldNumeric(rectRight, ref outputSettings.max, ref maxBufferString, 0);
+            }
+            if (outputSettings.min > outputSettings.max)
+            { 
+                minBufferString = outputSettings.max.ToString();
             }
             list.End();
         }


### PR DESCRIPTION
In the old code, if outputMin > outputMax in setting, IO port would never update, even if useMin and/or useMax isn't enabled.
This fix adds additional checks for if useMin and useMax are both enabled before checking if outputMin > outputMax.