### PR TITLE
(experimental) improved belt performance

### DIFF
--- a/Source/ProjectRimFactory/AutoMachineTool/Building_BaseRange.cs
+++ b/Source/ProjectRimFactory/AutoMachineTool/Building_BaseRange.cs
@@ -2,6 +2,7 @@
 using RimWorld;
 using System.Collections.Generic;
 using System.Linq;
+using UnityEngine;
 using Verse;
 using static ProjectRimFactory.AutoMachineTool.Ops;
 

--- a/Source/ProjectRimFactory/AutoMachineTool/Building_BeltConveyor.cs
+++ b/Source/ProjectRimFactory/AutoMachineTool/Building_BeltConveyor.cs
@@ -296,10 +296,11 @@ namespace ProjectRimFactory.AutoMachineTool
         public override void DeSpawn(DestroyMode mode = DestroyMode.Vanish)
         {
             var targets = AllNearbyLinkables().ToList();
+            PatchStorageUtil.GetPRFMapComponent(this.Map).NextBeltCache.Clear();
             base.DeSpawn(mode);
 
             targets.ForEach(x => x.Unlink(this));
-            PatchStorageUtil.GetPRFMapComponent(this.Map).NextBeltCache.Clear();
+            
         }
         // What does this even mean for a building, anyway?
         public override bool CanStackWith(Thing other)

--- a/Source/ProjectRimFactory/AutoMachineTool/Building_BeltSplitter.cs
+++ b/Source/ProjectRimFactory/AutoMachineTool/Building_BeltSplitter.cs
@@ -205,11 +205,11 @@ namespace ProjectRimFactory.AutoMachineTool
                 if (priority == prevPriority) yield return previousDir;
             }
         }
-        protected override IBeltConveyorLinkable OutputBeltAt(IntVec3 location)
+        protected override IBeltConveyorLinkable OutputBelt()
         {
             foreach (var kvp in this.outputLinks)
             {
-                if (kvp.Key.FacingCell + this.Position == location)
+                if (kvp.Key.FacingCell + this.Position == this.OutputCell())
                 {
                     if (!kvp.Value.Active) return null;
                     return kvp.Value.link;

--- a/Source/ProjectRimFactory/Common/PRFMapComponent.cs
+++ b/Source/ProjectRimFactory/Common/PRFMapComponent.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using ProjectRimFactory.AutoMachineTool;
+using System.Collections.Generic;
 using System.Linq;
 using Verse;
 
@@ -19,6 +20,9 @@ namespace ProjectRimFactory.Common
         private Dictionary<IntVec3, ProjectRimFactory.Storage.Building_AdvancedStorageUnitIOPort> advancedIOLocations = new Dictionary<IntVec3, Storage.Building_AdvancedStorageUnitIOPort>();
 
         public Dictionary<IntVec3, ProjectRimFactory.Storage.Building_AdvancedStorageUnitIOPort> GetadvancedIOLocations => advancedIOLocations;
+
+        public Dictionary<Building_BeltConveyor, IBeltConveyorLinkable> NextBeltCache = new Dictionary<Building_BeltConveyor, IBeltConveyorLinkable>();
+
 
         public void RegisterColdStorageBuilding(ProjectRimFactory.Storage.Building_ColdStorage port)
         {


### PR DESCRIPTION
Needs some Testing.

Improves Performance by Optimizing the use of the `OutputBeltAt` Function
The Function was always used with the Same Parameter `OutputCell()` Since that value only changes when the Building is Placed, that means that it can be cached. Clearing the cache only when it is moved.

_may need to check if the cache is cleared on reinstall_
_should we ever add a rotate after placement, that would need to clear aswell_

**Note: the numbers are misleading due to the use of profiling the Type. Actual load is much lower in both cases**

Before
![BeltProfile](https://user-images.githubusercontent.com/68663281/216977403-983b92d5-56ff-4992-ade0-68bf3fbb9304.png)

After
![BeltCache](https://user-images.githubusercontent.com/68663281/216977469-bc6b2bf1-9fc3-4c0b-84cd-0ac66df018f2.png)
