### PR TITLE
#678 removed unnecessary checks

### DIFF
--- a/Source/ProjectRimFactory/Common/HarmonyPatches/PatchStorage.cs
+++ b/Source/ProjectRimFactory/Common/HarmonyPatches/PatchStorage.cs
@@ -32,12 +32,10 @@ namespace ProjectRimFactory.Common.HarmonyPatches
         static bool Prefix(Building_Storage __instance, Thing t, out bool __result)
         {
             __result = false;
+            //Check if pawn input is forbidden
             if ((__instance as IForbidPawnInputItem)?.ForbidPawnInput ?? false)
             {
-                if (!__instance.slotGroup.HeldThings.Contains(t))
-                {
-                    return false;
-                }
+                return false;
             }
             return true;
         }


### PR DESCRIPTION
resolves #678 

I did some testing and it turns out that
- `System.Linq.Enumerable:Contains`
- `Rimwold.SlotGroup:get_HeldThings`
Only show up on DSU where Allow Pawn Input is set to false.
Further testing showed that the only items affected by that additional check are the items inside the DSU

Removing the check appears to have no side effect.

![Patch_Building_Storage_Accepts_Internal_ano](https://user-images.githubusercontent.com/68663281/219853894-d7653c04-46f4-420f-8ce3-ea005c900374.png)

The load of the **removed** calls was based on the amount of items in the DSU and the count of DSU's.
For the Screenshot this more then halves the impact.
