### PR TITLE
SAL Cooking Industrial -> Spacer

### DIFF
--- a/Defs/ResearchProjectDefs/ResearchProjects_SAL.xml
+++ b/Defs/ResearchProjectDefs/ResearchProjects_SAL.xml
@@ -95,7 +95,7 @@
   <ResearchProjectDef ParentName="PRF_SALResearch">
     <defName>PRF_SALResearchVII</defName>
     <label>S.A.L Autonomous Cooking</label>
-    <techLevel>Industrial</techLevel>
+    <techLevel>Spacer</techLevel>
     <baseCost>2000</baseCost>
     <description>Learn how to give auto-assemblers enough dexterity and precision for them to efficiently replace your chefs.</description>
     <prerequisites>


### PR DESCRIPTION
Playing with techadvance, this is always bugging the hell out of me. It needs all techs researched before advancing, but: SAL Cooking (industrial tech) has a prerequisite SAL Specialisation (spacer tech). Angry screeching.