### PR TITLE
Resolved issues with Splitters linking into eachother

### DIFF
--- a/Source/ProjectRimFactory/AutoMachineTool/Building_BeltSplitter.cs
+++ b/Source/ProjectRimFactory/AutoMachineTool/Building_BeltSplitter.cs
@@ -307,13 +307,35 @@ namespace ProjectRimFactory.AutoMachineTool
                 incomingLinks.Add(link);
                 if (PositionToRot4(link, out Rot4 r))
                 {
-                    if (outputLinks.TryGetValue(r, out OutputLink output))
+                    if (outputLinks.TryGetValue(r, out OutputLink output) && IsInputtingIntoThis(link, r))
                     {
                         output.Active = false;
                     }
                 }
             }
         }
+
+
+        /// <summary>
+        /// Helper Function use to Check if a IBeltConveyorLinkable is acting as an Input for this building
+        /// </summary>
+        /// <param name="link">IBeltConveyorLinkable</param>
+        /// <param name="r">Direction of the IBeltConveyorLinkable</param>
+        /// <returns>True if link acts as an Input</returns>
+        public bool IsInputtingIntoThis(IBeltConveyorLinkable link, Rot4 r)
+        {
+            if (link is Building_BeltSplitter building_Belt)
+            {
+                building_Belt.outputLinks.TryGetValue(r.Opposite, out OutputLink output);
+                return output is not null && output.Active;
+            }
+            else
+            {
+                return link.Rotation.Opposite == r;
+            }
+        }
+
+
         // Utility fn for linking to belt link
         private bool PositionToRot4(IBeltConveyorLinkable link, out Rot4 r)
         {

--- a/Source/ProjectRimFactory/AutoMachineTool/ITab_ConveyorFilter.cs
+++ b/Source/ProjectRimFactory/AutoMachineTool/ITab_ConveyorFilter.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
+using UnityEngine.UIElements;
 using Verse;
 using static ProjectRimFactory.AutoMachineTool.Ops;
 
@@ -154,25 +155,13 @@ namespace ProjectRimFactory.AutoMachineTool
                 }
 
                 bool selref = selectedDir == dir;
-
                 bool isInput = false;
+                
                 foreach (IBeltConveyorLinkable linkable in Splitter.IncomingLinks.Where(l => l.Position == (Splitter.Position + dir.FacingCell)))
                 {
-                    if ((linkable as Building_BeltConveyor) != null || (linkable as Building_BeltConveyorUGConnector) != null)
-                    {
-                        if (OppositeRot(linkable.Rotation) == dir)
-                        {
-                            isInput = true;
-                            break;
-                        }
-                    }
-                    else if ((linkable as Building_BeltSplitter) != null)
-                    {
-                        //Seperate Logic for splitters 
-                        if ((linkable as Building_BeltSplitter).OutputLinks.Keys.Contains(OppositeRot(dir)) && (linkable as Building_BeltSplitter).OutputLinks[OppositeRot(dir)].Active) isInput = true;
 
-                    }
-
+                    isInput = Splitter.IsInputtingIntoThis(linkable, dir);
+                    if (isInput) break;
                 }
 
 


### PR DESCRIPTION
resolves #452 
Only deactivates Output if they are used as an Input
fixed GUI Input Detection for Splitters