### PR TITLE
Excluded Wastepack from Destroy Anything and Added alternative

### DIFF
--- a/Defs/RecipeDefs/Recipes_Recycle.xml
+++ b/Defs/RecipeDefs/Recipes_Recycle.xml
@@ -172,6 +172,9 @@
         <li>BodyParts</li>
         <li>Buildings</li>
       </categories>
+      <disallowedThingDefs MayRequire="Ludeon.RimWorld.Biotech">
+        <li MayRequire="Ludeon.RimWorld.Biotech">Wastepack</li>
+      </disallowedThingDefs>
     </fixedIngredientFilter>
   </RecipeDef>
 

--- a/Patches/Biotech.xml
+++ b/Patches/Biotech.xml
@@ -8,12 +8,6 @@
       <success>Always</success>
       <operations>
       <li Class="PatchOperationAdd">
-		<xpath>/Defs/ThingDef[defName = "PRF_Recycler"]/recipes</xpath>
-		<value>
-		  <li>PRF_Destroy_Wastepack</li>
-		</value>
-      </li>
-      <li Class="PatchOperationAdd">
         <xpath>/Defs</xpath>
         <value>
           <RecipeDef>
@@ -45,6 +39,12 @@
               </li>
             </ingredients>
           </RecipeDef>
+        </value>
+      </li>
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs/ThingDef[defName = "PRF_Recycler"]/recipes</xpath>
+        <value>
+          <li>PRF_Destroy_Wastepack</li>
         </value>
       </li>
       </operations>

--- a/Patches/Biotech.xml
+++ b/Patches/Biotech.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Biotech</li>
+    </mods>
+    <match Class="PatchOperationSequence">
+      <success>Always</success>
+      <operations>
+      <li Class="PatchOperationAdd">
+		<xpath>/Defs/ThingDef[defName = "PRF_Recycler"]/recipes</xpath>
+		<value>
+		  <li>PRF_Destroy_Wastepack</li>
+		</value>
+      </li>
+      <li Class="PatchOperationAdd">
+        <xpath>/Defs</xpath>
+        <value>
+          <RecipeDef>
+            <defName>PRF_Destroy_Wastepack</defName>
+            <label>destroy Wastepack</label>
+            <description>Destroy Wastepack.</description>
+            <jobString>Pulverizing Wastepack.</jobString>
+            <workAmount>8000</workAmount>
+            <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
+            <effectWorking>Cremate</effectWorking>
+            <soundWorking>Recipe_Cremate</soundWorking>
+            <autoStripCorpses>false</autoStripCorpses>
+            <ingredients>
+              <li>
+                <filter>
+                  <thingDefs>
+                    <li>Neutroamine</li>
+                  </thingDefs>
+                </filter>
+                <count>8</count>
+              </li>
+              <li>
+                <filter>
+                  <thingDefs>
+                    <li>Wastepack</li>
+                  </thingDefs>
+                </filter>
+                <count>1</count>
+              </li>
+            </ingredients>
+          </RecipeDef>
+        </value>
+      </li>
+      </operations>
+    </match>
+  </Operation>
+</Patch>


### PR DESCRIPTION
resolves #664 

Adds a Bill that consumes 8 Neutroamine to destroy a Wastepack.
It is faster than the Vanilla Option but not too fast