### PR TITLE
fix(#773): weather masks over roofed pullers

### DIFF
--- a/Defs/ThingDefs_Buildings/Buildings_Logistics.xml
+++ b/Defs/ThingDefs_Buildings/Buildings_Logistics.xml
@@ -100,7 +100,7 @@
     <fillPercent>0.5</fillPercent>
     <pathCost>70</pathCost>
     <building>
-	  <isHopper>true</isHopper>
+      <isHopper>true</isHopper>
       <fixedStorageSettings>
         <priority>Preferred</priority>
         <filter>
@@ -206,6 +206,7 @@
     <minifiedDef>MinifiedThing</minifiedDef>    <!-- Sets if a item should be moveable vanilla reinstall/uninstall -->
     <size>(1,1)</size>
     <fillPercent>0.5</fillPercent>
+    <blockWeather>true</blockWeather>
     <passability>Standable</passability>
     <rotatable>true</rotatable>
     <drawPlaceWorkersWhileSelected>true</drawPlaceWorkersWhileSelected>
@@ -249,7 +250,7 @@
     <label>growzone puller</label>
     <description>A specialized puller that will pull from adjacent grow zones. It must be connected to the grow zone to function properly.</description>
     <fillPercent>1</fillPercent>
-	<placeWorkers>
+    <placeWorkers>
       <li>ProjectRimFactory.Common.PlaceWorker_GrowZonePuller</li>
     </placeWorkers>
     <costList>      <!-- Remove in Lite -->
@@ -315,7 +316,7 @@
     <label>item puller Mk.I</label>
     <description>A device that pulls items from the input (white cell) and pushes them to the output (yellow cell). Turn it on after setting the filters.\nThis device is very flexible in its connections and works with stockpiles, storage, belts (all versions), I/O, and others.</description>    <!--todo: maybe make a message on spawn if not turned on-->
     <fillPercent>1</fillPercent>
-	<costList>      <!-- Remove in Lite -->
+    <costList>      <!-- Remove in Lite -->
       <PRF_RoboticArm>1</PRF_RoboticArm>
       <PRF_MachineFrame_I>1</PRF_MachineFrame_I>
     </costList>
@@ -369,7 +370,7 @@
     <label>item puller Mk.II</label>
     <description>An optimized puller that runs at higher speeds. Pulls from input (white cell) to output (yellow cell). Very flexible in its connections.</description>    <!--todo: maybe make a message on spawn if not turned on-->
     <fillPercent>1</fillPercent>
-	<costList>
+    <costList>
       <ComponentIndustrial>5</ComponentIndustrial>
       <PRF_RoboticArm>2</PRF_RoboticArm>
       <PRF_MachineFrame_I>1</PRF_MachineFrame_I>
@@ -415,7 +416,7 @@
     <label>item angle puller</label>
     <description>A specialized puller designed to pull items at a 90-degree angle. Functionally similar to the normal puller. Directions can be swapped after placing.</description>
     <fillPercent>1</fillPercent>
-	<costList>
+    <costList>
       <ComponentIndustrial>5</ComponentIndustrial>
       <PRF_RoboticArm>2</PRF_RoboticArm>
       <PRF_MachineFrame_I>1</PRF_MachineFrame_I>


### PR DESCRIPTION
## Changes
* added `blockweather` tag to `PRF_Puller_Base`
* formatted the document to fix odd indentation

## Pics

### Before
![image](https://github.com/zymex22/Project-RimFactory-Revived/assets/3701326/7a081028-5308-4f6c-91f6-f6ca54f531be)

### After
![image](https://github.com/zymex22/Project-RimFactory-Revived/assets/3701326/a76d60c5-d282-4261-9ed4-a03191c93853)
