### PR TITLE
Fixed Null Ref wehen crafting items with NULL Quality

### DIFF
--- a/Source/ProjectRimFactory/AutoMachineTool/GenRecipe2.cs
+++ b/Source/ProjectRimFactory/AutoMachineTool/GenRecipe2.cs
@@ -145,19 +145,19 @@ namespace ProjectRimFactory.AutoMachineTool
                 QualityCategory qualityCategory = QualityUtility.GenerateQualityCreatedByPawn(level, false);
                 compQuality.SetQuality(qualityCategory, ArtGenerationContext.Colony);
             }
-            CompArt compArt = product.TryGetComp<CompArt>();
+            /*CompArt compArt = product.TryGetComp<CompArt>();
             if (compArt != null)
             {
                 if (compQuality.Quality >= QualityCategory.Excellent)
                 {
-                    /*
+                    
                     TaleRecorder.RecordTale(TaleDefOf.CraftedArt, new object[]
                     {
                         product
                     });
-                    */
+                   
                 }
-            }
+            }*/
             if (precept != null)
             {
                 product.StyleSourcePrecept = precept;


### PR DESCRIPTION
Closing #823 
resolved issue by commenting out unused cod path

I'm Commenting the Code out instead of removing it to help future me correlate it better the the Vanilla function that it replicates.
This should aid in future updates