### PR TITLE
#810 Fixed issue with IO pusher not using max

### DIFF
--- a/Source/ProjectRimFactory/Storage/Building_StorageUnitIOPort.cs
+++ b/Source/ProjectRimFactory/Storage/Building_StorageUnitIOPort.cs
@@ -324,14 +324,14 @@ namespace ProjectRimFactory.Storage
                             }
                         }
                     }
-                    //Transfre a item back if it is either too few or disallowed
-                    if (currentItem != null && (!settings.AllowedToAccept(currentItem) || !OutputSettings.SatisfiesMin(currentItem.stackCount)) && boundStorageUnit.GetSettings.AllowedToAccept(currentItem))
+                    // Transfer a item back if it is either too few or disallowed
+                    if (currentItem != null && !OutputSettings.useMax &&  (!settings.AllowedToAccept(currentItem) || !OutputSettings.SatisfiesMin(currentItem.stackCount)) && boundStorageUnit.GetSettings.AllowedToAccept(currentItem))
                     {
                         currentItem.SetForbidden(false, false);
                         boundStorageUnit.HandleNewItem(currentItem);
                     }
-                    //Transfer the diffrence back if it is too much
-                    if (currentItem != null && (!OutputSettings.SatisfiesMax(currentItem.stackCount, currentItem.def.stackLimit) && boundStorageUnit.GetSettings.AllowedToAccept(currentItem)))
+                    // Transfer the difference back if it is too much
+                    if (currentItem != null && OutputSettings.useMax && (!OutputSettings.SatisfiesMax(currentItem.stackCount, currentItem.def.stackLimit) && boundStorageUnit.GetSettings.AllowedToAccept(currentItem)))
                     {
                         int splitCount = -OutputSettings.CountNeededToReachMax(currentItem.stackCount, currentItem.def.stackLimit);
                         if (splitCount > 0)


### PR DESCRIPTION
Added OutputSettings.useMax as a condition when transferring items which seems to fix the issue for the IO pusher (see video demo).

https://github.com/user-attachments/assets/612261f0-fe8d-4b3a-bf89-ccf28d6b56eb

