### PR TITLE
Added Wastepacks to Fridge I/O Port

### DIFF
--- a/Patches/Fridge/RimFridge.xml
+++ b/Patches/Fridge/RimFridge.xml
@@ -55,6 +55,7 @@
 										</categories>
 										<thingDefs>
 											<li>Wort</li>
+											<li MayRequire="Ludeon.RimWorld.Biotech">Wastepack</li>
 										</thingDefs>
 										<specialFiltersToDisallow>
 											<li>AllowRotten</li>

--- a/Patches/Fridge/SimpleFridge.xml
+++ b/Patches/Fridge/SimpleFridge.xml
@@ -51,6 +51,7 @@
 										</categories>
 										<thingDefs>
 											<li>Wort</li>
+											<li MayRequire="Ludeon.RimWorld.Biotech">Wastepack</li>
 										</thingDefs>
 										<specialFiltersToDisallow>
 											<li>AllowRotten</li>

--- a/Patches/Fridge/Vanilla_Recycling_Expanded.xml
+++ b/Patches/Fridge/Vanilla_Recycling_Expanded.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>RimFridge: Now with Shelves!</li>
+      <li>Simple Utilities: Fridge</li>
+    </mods>
+    <match Class="PatchOperationFindMod">
+      <mods>
+        <li>Vanilla Recycling Expanded</li>
+      </mods>
+      <match Class="PatchOperationSequence">
+        <success>Always</success>
+        <operations>
+          <li Class="PatchOperationAdd">
+            <xpath>/Defs/ThingDef[defName = "PRF_IOPort_IFridge"]/building/fixedStorageSettings/filter/categories</xpath>
+            <value>
+              <li MayRequire="Ludeon.RimWorld.Biotech">VRecyclingE_SpecializedPacks</li>
+            </value>
+          </li>
+        </operations>
+      </match>
+    </match>
+  </Operation>
+</Patch>


### PR DESCRIPTION
Added for both Simple Fridge and RimFridge.

If the user has Biotech installed, they can ask for wastepacks. If they have Biotech AND Vanilla Recycling Expanded, then they can also ask for specialized packs.