### PR TITLE
#899 Disable map temperature check in `TryPlantNew`

### DIFF
--- a/Source/ProjectRimFactory/CultivatorTools/Building_Cultivator.cs
+++ b/Source/ProjectRimFactory/CultivatorTools/Building_Cultivator.cs
@@ -87,7 +87,7 @@ namespace ProjectRimFactory.CultivatorTools
                 //Only Plant if seed is available
                 if (!SeedsPleaseSupport.TryPlantNew(plantDef, SeedsPleaseSupport.InputArea(this), Map)) return;
             }
-            if (plantDef.CanEverPlantAt(c, Map) && PlantUtility.AdjacentSowBlocker(plantDef, c, Map) == null)
+            if (plantDef.CanEverPlantAt(c, Map, checkMapTemperature: false) && PlantUtility.AdjacentSowBlocker(plantDef, c, Map) == null)
             {
                 GenPlace.TryPlaceThing(ThingMaker.MakeThing(plantDef), c, Map, ThingPlaceMode.Direct);
             }


### PR DESCRIPTION
- Setting `checkMapTemperature: false` in `CanEverPlantAt` condition check enables nano cultivator to sow plants during extreme temperatures on a map